### PR TITLE
Fix incorrect shotgun gauge names

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -324,10 +324,10 @@
 
 # Shotgun
 - type: entity
-  name: box of (.12 pellet) ammo drums
+  name: box of (12 gauge pellet) ammo drums
   parent: BoxCardboard
   id: BoxMagazineShotgun
-  description: A box full of (.12 pellet) ammo drums.
+  description: A box full of (12 gauge pellet) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -335,10 +335,10 @@
         amount: 6
 
 - type: entity
-  name: box of (.12 beanbag) ammo drums
+  name: box of (12 gauge beanbag) ammo drums
   parent: BoxCardboard
   id: BoxMagazineShotgunBeanbag
-  description: A box full of (.12 beanbag) ammo drums.
+  description: A box full of (12 gauge beanbag) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -346,10 +346,10 @@
         amount: 6
 
 - type: entity
-  name: box of (.12 slug) ammo drums
+  name: box of (12 gauge slug) ammo drums
   parent: BoxCardboard
   id: BoxMagazineShotgunSlug
-  description: A box full of (.12 slug) ammo drums.
+  description: A box full of (12 gauge slug) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -357,10 +357,10 @@
         amount: 6
 
 - type: entity
-  name: box of (.12 incendiary) ammo drums
+  name: box of (12 gauge incendiary) ammo drums
   parent: BoxCardboard
   id: BoxMagazineShotgunIncendiary
-  description: A box full of (.12 incendiary) ammo drums.
+  description: A box full of (12 gauge incendiary) ammo drums.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: BaseShellShotgun
-  name: shell (.12)
+  name: shell (12 gauge)
   parent: BaseCartridge
   abstract: true
   components:
@@ -24,7 +24,7 @@
 
 - type: entity
   id: ShellShotgunBeanbag
-  name: shell (.12 beanbag)
+  name: shell (12 gauge beanbag)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -39,7 +39,7 @@
 
 - type: entity
   id: ShellShotgunSlug
-  name: shell (.12 slug)
+  name: shell (12 gauge slug)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -55,7 +55,7 @@
 
 - type: entity
   id: ShellShotgunFlare
-  name: shell (.12 flare)
+  name: shell (12 gauge flare)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -70,7 +70,7 @@
 
 - type: entity
   id: ShellShotgun
-  name: shell (.12)
+  name: shell (12 gauge)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -82,7 +82,7 @@
 
 - type: entity
   id: ShellShotgunIncendiary
-  name: shell (.12 incendiary)
+  name: shell (12 gauge incendiary)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -96,7 +96,7 @@
 
 - type: entity
   id: ShellShotgunPractice
-  name: shell (.12 practice)
+  name: shell (12 gauge practice)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -110,7 +110,7 @@
 
 - type: entity
   id: ShellTranquilizer
-  name: shell (.12 tranquilizer)
+  name: shell (12 gauge tranquilizer)
   parent: BaseShellShotgun
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseMagazineShotgun
-  name: ammo drum (.12 shells)
+  name: ammo drum (12 gauge shells)
   parent: BaseItem
   abstract: true
   components:
@@ -35,7 +35,7 @@
 
 - type: entity
   id: MagazineShotgun
-  name: ammo drum (.12 pellet)
+  name: ammo drum (12 gauge pellet)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -49,7 +49,7 @@
 
 - type: entity
   id: MagazineShotgunBeanbag
-  name: ammo drum (.12 beanbags)
+  name: ammo drum (12 gauge beanbags)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -63,7 +63,7 @@
 
 - type: entity
   id: MagazineShotgunSlug
-  name: ammo drum (.50 slug)
+  name: ammo drum (12 gauge slug)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -77,7 +77,7 @@
 
 - type: entity
   id: MagazineShotgunIncendiary
-  name: ammo drum (.12 incendiary)
+  name: ammo drum (12 gauge incendiary)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Shotgun sizes have always been measured in a somewhat roundabout way. You would think that the "12" in a 12-gauge shotgun corresponds to some linear measurement -- maybe inches or centimeters. But that's not the case. "12-gauge" means you can make 12 lead balls, each of equal diameter to the gun barrel, out of 1 pound of lead. This originated in the days when you would buy lead by the pound to make your own ammo. The gauge told you how many rounds you could make for the gun from 1 pound of lead.


alternatively you can also replace "12 gauge" with "12ga" if you prefer it shorter
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->


