### PR TITLE
It's locked! popup on access denied

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -10,12 +10,14 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Timing;
 using System.Linq;
+using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Content.Shared.Tools.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
 
 namespace Content.Shared.Doors.Systems;
 
@@ -29,6 +31,7 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] protected readonly SharedPopupSystem _popupSystem = default!;
 
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
@@ -203,6 +206,8 @@ public abstract class SharedDoorSystem : EntitySystem
             return;
 
         SetState(uid, DoorState.Denying, door);
+
+        _popupSystem.PopupEntity(Loc.GetString("airlock-component-access-denied"), uid, Filter.Pvs(uid), PopupType.Small);
 
         if (door.DenySound != null)
             PlaySound(uid, door.DenySound, AudioParams.Default.WithVolume(-3), user, predicted);

--- a/Resources/Locale/en-US/_frigid/door.ftl
+++ b/Resources/Locale/en-US/_frigid/door.ftl
@@ -1,0 +1,1 @@
+﻿airlock-component-access-denied = It's locked!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds "It's locked!" to doors when the user doesn't have sufficient access. tldr a way to signal "no access"

**Screenshots**
![image](https://user-images.githubusercontent.com/67359748/192259995-944d353f-bfe9-42b8-9361-7b783c128e29.png)


**Changelog**
cl 4 nerds