### PR TITLE
wood

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -769,7 +769,7 @@
   - type: Icon
     sprite: Structures/Walls/wood.rsi
   - type: Construction
-    graph: Girder
+    graph: Barricade
     node: woodWall
   - type: Destructible
     thresholds:
@@ -787,7 +787,7 @@
         sound:
           path: /Audio/Effects/metalbreak.ogg
       - !type:ChangeConstructionNodeBehavior
-        node: girder
+        node: barricadewooden
       - !type:DoActsBehavior
         acts: ["Destruction"]
     destroySound:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -25,6 +25,7 @@
           steps:
             - tool: Prying
               doAfter: 5
+        # wood
         - to: woodWall
           completed:
             - !type:SnapToGrid
@@ -33,8 +34,8 @@
             - !type:EntityAnchored {}
           steps:
             - material: WoodPlank
-              amount: 1
-              doAfter: 5
+              amount: 3
+              doAfter: 3
     - node: woodWall
       entity: WallWood
       edges:
@@ -42,7 +43,7 @@
           completed:
             - !type:GivePrototype
               prototype: MaterialWoodPlank1
-              amount: 2
+              amount: 3
           steps:
             - tool: Prying
-              doAfter: 10
+              doAfter: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -25,3 +25,24 @@
           steps:
             - tool: Prying
               doAfter: 5
+        - to: woodWall
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - material: WoodPlank
+              amount: 1
+              doAfter: 5
+    - node: woodWall
+      entity: WallWood
+      edges:
+        - to: barricadewooden
+          completed:
+            - !type:GivePrototype
+              prototype: MaterialWoodPlank1
+              amount: 2
+          steps:
+            - tool: Prying
+              doAfter: 10

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -56,16 +56,6 @@
               amount: 5
               doAfter: 15
 
-        - to: woodWall
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored {}
-          steps:
-            - material: WoodPlank
-              amount: 1
-              doAfter: 5
 
         - to: uraniumWall
           completed:
@@ -137,18 +127,6 @@
           steps:
             - tool: Welding
               doAfter: 30
-
-    - node: woodWall
-      entity: WallWood
-      edges:
-        - to: girder
-          completed:
-            - !type:GivePrototype
-              prototype: MaterialWoodPlank1
-              amount: 2
-          steps:
-            - tool: Prying
-              doAfter: 10
 
     - node: uraniumWall
       entity: WallUranium

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -73,11 +73,11 @@
 - type: construction
   name: wood wall
   id: WoodWall
-  graph: Girder
+  graph: Barricade
   startNode: start
   targetNode: woodWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps you in and the zombies out.
   icon:
     sprite: Structures/Walls/wood.rsi
     state: full


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wood walls no longer need steel to make.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: PixelTK
- tweak: the old blueprints for wooden walls showed an unnecessary need for steel, so we got rid of them and made new ones. Now your new walls will be 99% wood