### PR TITLE
Zombie changes and SunSystem fixes

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/ChemTreatInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/ChemTreatInfection.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Server.Disease;
+using JetBrains.Annotations;
+
+namespace Content.Server.Chemistry.ReagentEffects;
+/// <summary>
+/// Default metabolism for medicine reagents.
+/// </summary>
+[UsedImplicitly]
+public sealed class ChemTreatInfection : ReagentEffect
+{
+    public override void Effect(ReagentEffectArgs args)
+    {
+        var ev = new TreatInfectionAttemptEvent();
+        args.EntityManager.EventBus.RaiseLocalEvent(args.SolutionEntity, ev, false);
+    }
+}

--- a/Content.Server/Disease/DiseaseSystem.cs
+++ b/Content.Server/Disease/DiseaseSystem.cs
@@ -532,12 +532,12 @@ namespace Content.Server.Disease
         }
     }
 
-        /// <summary>
-        /// This event is fired by chems
-        /// and other brute-force rather than
-        /// specific cures. It will roll the dice to attempt
-        /// to cure each disease on the target
-        /// </summary>
+    /// <summary>
+    /// This event is fired by chems
+    /// and other brute-force rather than
+    /// specific cures. It will roll the dice to attempt
+    /// to cure each disease on the target
+    /// </summary>
     public sealed class CureDiseaseAttemptEvent : EntityEventArgs
     {
         public float CureChance { get; }

--- a/Content.Server/Zombies/ZombieDamageComponent.cs
+++ b/Content.Server/Zombies/ZombieDamageComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Server.Zombies;
+
+[RegisterComponent]
+public sealed class ZombieDamageComponent : Component
+{
+    /// <summary>
+    /// The accumulated infection damage, reaching 1f will immediately infect you. Antibiotics can lower this damage.
+    /// </summary>
+    [ViewVariables] public float InfectionDamage = 0f;
+}

--- a/Content.Server/Zombies/ZombifyOnDeathSystem.cs
+++ b/Content.Server/Zombies/ZombifyOnDeathSystem.cs
@@ -97,6 +97,9 @@ namespace Content.Server.Zombies
             if (HasComp<ZombieComponent>(target))
                 return;
 
+            // Remove the mind
+            RemComp<MindComponent>(target);
+
             if (randomizeAppearance)
             {
                 // I would just EnsureComp a RandomHumanoidAppearance component however that just
@@ -188,11 +191,6 @@ namespace Content.Server.Zombies
             if (TryComp<DamageableComponent>(target, out var damageablecomp))
                 _damageable.SetAllDamage(damageablecomp, 0);
 
-            //gives it the funny "Zombie ___" name.
-            // if (TryComp<MetaDataComponent>(target, out var meta))
-            // meta.EntityName = Loc.GetString("zombie-name-prefix", ("target", meta.EntityName));
-            // _identity.QueueIdentityUpdate(target);
-
             //He's gotta have a mind
             //UNLESS they're an AI
             TryComp<HTNComponent>(target, out var utilityNpcComponent);
@@ -229,6 +227,7 @@ namespace Content.Server.Zombies
 
             //zombie gamemode stuff
             RaiseLocalEvent(new EntityZombifiedEvent(target));
+
             //zombies get slowdown once they convert
             _movementSpeedModifier.RefreshMovementSpeedModifiers(target);
         }

--- a/Content.Server/_Frigid/Sun/SunSystem.cs
+++ b/Content.Server/_Frigid/Sun/SunSystem.cs
@@ -23,9 +23,6 @@ public sealed class SunSystem : SharedSunSystem
 
     private void PlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
-        if (e.NewStatus != SessionStatus.Disconnected && e.NewStatus != SessionStatus.Zombie)
-            return;
-
         var user = e.Session;
         UpdateLighting(user);
     }

--- a/Content.Shared/Zombies/SharedZombieSystem.cs
+++ b/Content.Shared/Zombies/SharedZombieSystem.cs
@@ -1,9 +1,12 @@
 ﻿using Content.Shared.Movement.Systems;
+using Robust.Shared.Random;
 
 namespace Content.Shared.Zombies;
 
 public abstract class SharedZombieSystem : EntitySystem
 {
+    [Dependency] private IRobustRandom _robustRandom = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -14,7 +17,7 @@ public abstract class SharedZombieSystem : EntitySystem
 
     private void OnRefreshSpeed(EntityUid uid, ZombieComponent component, RefreshMovementSpeedModifiersEvent args)
     {
-        var mod = component.ZombieMovementSpeedDebuff;
+        var mod = _robustRandom.NextFloat(component.ZombieMovementRandomSpeedMinimum, component.ZombieMovementRandomSpeedMaximum);
         args.ModifySpeed(mod, mod);
     }
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -3,62 +3,56 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Shared.Zombies
+namespace Content.Shared.Zombies;
+[RegisterComponent, NetworkedComponent]
+public sealed class ZombieComponent : Component
 {
-    [RegisterComponent, NetworkedComponent]
-    public sealed class ZombieComponent : Component
-    {
-        /// <summary>
-        /// The coefficient of the damage reduction applied when a zombie
-        /// attacks another zombie. longe name
-        /// </summary>
-        [ViewVariables]
-        public float OtherZombieDamageCoefficient = 0.5f;
+    /// <summary>
+    /// The coefficient of the damage reduction applied when a zombie
+    /// attacks another zombie. longe name
+    /// </summary>
+    [ViewVariables]
+    public float OtherZombieDamageCoefficient = 0.5f;
 
-        /// <summary>
-        /// The baseline infection chance you have if you are completely nude
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.05f;
+    /// <summary>
+    /// The amount of infection damage one zombie deals.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float ZombieInfectionDamage = 0.1f;
 
-        /// <summary>
-        /// The minimum infection chance possible. This is simply to prevent
-        /// being invincible by bundling up.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.01f;
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float ZombieMovementRandomSpeedMinimum = 0.2f;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieMovementSpeedDebuff = 0.25f;
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float ZombieMovementRandomSpeedMaximum = 0.8f;
 
-        /// <summary>
-        /// The skin color of the zombie
-        /// </summary>
-        [DataField("skinColor")]
-        public Color SkinColor = new(0.45f, 0.51f, 0.29f);
+    /// <summary>
+    /// The skin color of the zombie
+    /// </summary>
+    [DataField("skinColor")]
+    public Color SkinColor = new(0.45f, 0.51f, 0.29f);
 
-        /// <summary>
-        /// The eye color of the zombie
-        /// </summary>
-        [DataField("eyeColor")]
-        public Color EyeColor = new(0.96f, 0.13f, 0.24f);
+    /// <summary>
+    /// The eye color of the zombie
+    /// </summary>
+    [DataField("eyeColor")]
+    public Color EyeColor = new(0.96f, 0.13f, 0.24f);
 
-        /// <summary>
-        /// The base layer to apply to any 'external' humanoid layers upon zombification.
-        /// </summary>
-        [DataField("baseLayerExternal")]
-        public string BaseLayerExternal = "MobHumanoidMarkingMatchSkin";
+    /// <summary>
+    /// The base layer to apply to any 'external' humanoid layers upon zombification.
+    /// </summary>
+    [DataField("baseLayerExternal")]
+    public string BaseLayerExternal = "MobHumanoidMarkingMatchSkin";
 
-        /// <summary>
-        /// The attack arc of the zombie
-        /// </summary>
-        [DataField("attackArc", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string AttackAnimation = "WeaponArcClaw";
+    /// <summary>
+    /// The attack arc of the zombie
+    /// </summary>
+    [DataField("attackArc", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string AttackAnimation = "WeaponArcClaw";
 
-        /// <summary>
-        /// The role prototype of the zombie antag role
-        /// </summary>
-        [ViewVariables, DataField("zombieRoldId", customTypeSerializer: typeof(PrototypeIdSerializer<AntagPrototype>))]
-        public readonly string ZombieRoleId = "Zombie";
-    }
+    /// <summary>
+    /// The role prototype of the zombie antag role
+    /// </summary>
+    [ViewVariables, DataField("zombieRoldId", customTypeSerializer: typeof(PrototypeIdSerializer<AntagPrototype>))]
+    public readonly string ZombieRoleId = "Zombie";
 }

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -507,6 +507,7 @@
     Medicine:
       effects:
         - !type:ChemCureDisease
+        - !type:ChemTreatInfection
 
 - type: reagent
   id: Stellibinin

--- a/Resources/Prototypes/_Frigid/Roles/Jobs/Security/military.yml
+++ b/Resources/Prototypes/_Frigid/Roles/Jobs/Security/military.yml
@@ -3,6 +3,7 @@
   name: job-name-soldier
   playTimeTracker: JobSoldier
   startingGear: SoldierGear
+  setPreference: false
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security


### PR DESCRIPTION
Closes #101

Previously, zombie infection was pure `prob()`, now it builds up. You can sustain around 10 hits from a zombie naked until you get infected, use antibiotics to lower the infection buildup.